### PR TITLE
[no-merge] Test to verify the fix for the MemoryError on AppVeyor and Python 2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,9 +73,19 @@ install:
 
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
+    - cmd: conda install -n root --yes --quiet jinja2 conda-build anaconda-client=1.5.1
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
-    - cmd: run_conda_forge_build_setup
+    - cmd: set CPU_COUNT=2
+    - cmd: set PYTHONUNBUFFERED=1
+
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --set add_pip_as_python_dependency false
+
+    - cmd: conda update -n root --yes --quiet conda
+    - cmd: conda install -n root --yes --quiet conda-build=1
+
+    - cmd: conda info
+    - cmd: conda config --get
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
This moves the content of [run_conda_forge_build_setup_win.bat](https://github.com/conda-forge/conda-forge-build-setup-feedstock/blob/master/recipe/run_conda_forge_build_setup_win.bat) into the appveyor.yml file of this feedstock, because the line causing the MemoryError was inside that other repo.

I did two modifications: The `- cmd: conda install -n root --yes --quiet jinja2 conda-build anaconda-client=1.5.1` line was moved in **front** of the `cmd: conda config --add channels conda-forge` line. And I specified the `anaconda-client`-version so it doesn't use 1.5.3

This results in two differences: The moved line does not throw a MemoryError anymore (thus saving approximatly 5-6 minutes build time) and `jinja2 2.8.0` will be kept instead of downgraded to `jinja2 2.7.2`.

I have absolutly no idea why this happens and how a "fix" could be applied to feedstocks or if it really fixes it. It just worked on my recipe.

It probably takes a while until the build here happens, so I started the build on my fork: https://ci.appveyor.com/project/MSeifert04/iteration-utilities-feedstock
The fork-build fails because I did not copy the [upload_or_check](upload_or_check_non_existence.py)-script but until then everything runs smooth.

@conda-forge/core 